### PR TITLE
FDP-217 Use CastorServer's Client Credentials when available

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,5 @@
+# These client credentials will be used as the default fallback. Per-server client credentials can be configured
+# in the /dashboard/edc-servers view.
 CASTOR_API_CLIENT='[Paste from 1Password]'
 CASTOR_API_SECRET='[Paste from 1Password]'
 

--- a/src/Controller/OAuth/CastorOAuthController.php
+++ b/src/Controller/OAuth/CastorOAuthController.php
@@ -23,10 +23,17 @@ class CastorOAuthController extends AbstractController
     {
         $request->getSession()->set('previous', $request->get('target_path'));
         $request->getSession()->set('castor.server', $server->getUrl()->getValue());
+        $request->getSession()->set('castor.server_id', $server->getId());
 
         return $clientRegistry
             ->getClient('castor')
-            ->redirect([], ['server' => $server->getUrl()->getValue()]);
+            ->redirect(
+                [],
+                [
+                    'server' => $server->getUrl()->getValue(),
+                    'server_id' => $server->getId(),
+                ]
+            );
     }
 
     /**

--- a/src/Security/Providers/Castor/CastorClient.php
+++ b/src/Security/Providers/Castor/CastorClient.php
@@ -20,6 +20,7 @@ class CastorClient extends OAuth2Client
 {
     public const OAUTH2_SESSION_STATE_KEY = 'knpu.oauth2_client_state';
     public const SESSION_SERVER_KEY = 'castor.server';
+    public const SESSION_SERVER_ID_KEY = 'castor.server_id';
 
     private CastorUserProvider $provider;
 
@@ -61,6 +62,7 @@ class CastorClient extends OAuth2Client
     {
         $expectedState = $this->getSession()->get(self::OAUTH2_SESSION_STATE_KEY);
         $server = $this->getSession()->get(self::SESSION_SERVER_KEY);
+        $serverId = (int) $this->getSession()->get(self::SESSION_SERVER_ID_KEY);
         $actualState = $this->getCurrentRequest()->query->get('state');
         if ($actualState === null || ($actualState !== $expectedState)) {
             throw new InvalidStateException('Invalid state');
@@ -72,7 +74,7 @@ class CastorClient extends OAuth2Client
             throw new MissingAuthorizationCodeException('No "code" parameter was found (usually this is a query parameter)!');
         }
 
-        return $this->provider->getAccessTokenWithServer($server, 'authorization_code', ['code' => $code]);
+        return $this->provider->getAccessTokenWithServer($server, $serverId, 'authorization_code', ['code' => $code]);
     }
 
     /**


### PR DESCRIPTION
When authenticating with an EDC server, we now use the Client Credentials
available in the database for the given server. This allows us to use
different client credentials per server, so that we don't need to copy
over client credentials from EDC database to EDC database.

We do this by overriding the AbstractProvider::clientId/clientSecret
when we start the authorization code and access token requests in the
CastorUserProvider.

If there are no client credentials available for a given server, we still
fallback to the ones specified in the .env file.