### PR TITLE
[FDP] Organizations cannot be added to metadata

### DIFF
--- a/src/Api/Request/Metadata/MetadataApiRequest.php
+++ b/src/Api/Request/Metadata/MetadataApiRequest.php
@@ -124,6 +124,9 @@ abstract class MetadataApiRequest extends SingleApiRequest
 
             if ($item['type'] === Organization::TYPE) {
                 $organization = Organization::fromData($item['organization']);
+                $agent = $organization;
+            } elseif ($item['type'] === Department::TYPE) {
+                $organization = Organization::fromData($item['organization']);
                 $department = Department::fromData($item['department'], $organization);
                 $agent = $department;
             } elseif ($item['type'] === Person::TYPE) {

--- a/src/Entity/FAIRData/Agent/Department.php
+++ b/src/Entity/FAIRData/Agent/Department.php
@@ -10,6 +10,8 @@ use function uniqid;
 /** @ORM\Entity */
 class Department extends Agent
 {
+    public const TYPE = 'department';
+
     /**
      * @ORM\ManyToOne(targetEntity="Organization",cascade={"persist"}, inversedBy="departments")
      * @ORM\JoinColumn(name="organization", referencedColumnName="id")

--- a/src/Validator/Constraints/AgentArrayValidator.php
+++ b/src/Validator/Constraints/AgentArrayValidator.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Validator\Constraints;
 
+use App\Entity\FAIRData\Agent\Department;
 use App\Entity\FAIRData\Agent\Organization;
 use App\Entity\FAIRData\Agent\Person;
 use Symfony\Component\Validator\Constraint;
@@ -36,7 +37,7 @@ class AgentArrayValidator extends ConstraintValidator
             if (! isset($agent['type'])) {
                 $this->context->buildViolation($constraint->noTypeMessage)->addViolation();
             } else {
-                if ($agent['type'] === Organization::TYPE) {
+                if ($agent['type'] === Department::TYPE) {
                     $collection = new Assert\Collection([
                         'allowExtraFields' => true,
                         'fields' => [
@@ -51,6 +52,31 @@ class AgentArrayValidator extends ConstraintValidator
                                     ],
                                 ],
                             ]),
+                            'organization' => new Assert\Collection([
+                                'allowExtraFields' => true,
+                                'fields' => [
+                                    'name' => [
+                                        new Assert\NotBlank(),
+                                        new Assert\Type(['type' => 'string']),
+                                    ],
+                                    'country' => [
+                                        new Assert\NotBlank(),
+                                        new Assert\Country(),
+                                    ],
+                                    'city' => [
+                                        new Assert\NotBlank(),
+                                        new Assert\Type(['type' => 'string']),
+                                    ],
+                                ],
+                            ]),
+                        ],
+                    ]);
+
+                    $this->mergeViolations($index, $agent, $collection, $constraint);
+                } elseif ($agent['type'] === Organization::TYPE) {
+                    $collection = new Assert\Collection([
+                        'allowExtraFields' => true,
+                        'fields' => [
                             'organization' => new Assert\Collection([
                                 'allowExtraFields' => true,
                                 'fields' => [

--- a/src/js/modals/PublisherModal.tsx
+++ b/src/js/modals/PublisherModal.tsx
@@ -33,10 +33,21 @@ export default class PublisherModal extends Component<PublisherModalProps, Publi
         const { handleSave } = this.props;
         const { type } = this.state;
 
-        handleSave({
-            type: type,
-            [type]: values,
-        });
+        if(type === 'organization') {
+            handleSave({
+                type: type,
+                organization: {
+                    ...values.organization,
+                    country: values.country,
+                },
+            });
+
+        } else {
+            handleSave({
+                type: type,
+                [type]: values,
+            });
+        }
 
         setSubmitting(false);
     };


### PR DESCRIPTION
In this PR I fixed a bug where organizations cannot be added to metadata. We introduced the support of Departments before (backend/DB only), but this broke the link between Organizations and Metadata. 

This PR makes sure you can add Organizations to Metadata again. Future work can focus on allowing for adding/selecting departments as well.